### PR TITLE
Add info about change of rest directory

### DIFF
--- a/Analyst Training/Exercise 10 - Network Analysis With Python/notebooks_and_constellation.ipynb
+++ b/Analyst Training/Exercise 10 - Network Analysis With Python/notebooks_and_constellation.ipynb
@@ -57,7 +57,7 @@
     "After the import succeeds, we then create a Python object that communicates with CONSTELLATION on our behalf. CONSTELLATION provides communication with the outside world using HTTP (as if it were a web server) and JSON (a common data format). The ``constellation_client`` library hides these details so you can just use Python.\n",
     "\n",
     "# IMPORTANT\n",
-    "If the \"REST Directory\" has been changed in Constellation's options, you must run the following to point constellation_client to the new folder for the \"REST Directory\". Be sure to replace `C:\\Path\\To\\Directory\\` with the actual filepath of the directory."
+    "If the \"REST Directory\" has been changed in Constellation's options, you must run the following to point constellation_client to the new folder for the \"REST Directory\". Be sure to replace `C:\\Path\\To\\Directory\\` with the actual filepath of the directory or the actual file itself."
    ]
   },
   {

--- a/Analyst Training/Exercise 10 - Network Analysis With Python/notebooks_and_constellation.ipynb
+++ b/Analyst Training/Exercise 10 - Network Analysis With Python/notebooks_and_constellation.ipynb
@@ -54,7 +54,19 @@
    "source": [
     "When the external scripting server started, it automatically installed the ``constellation_client`` package with pip install. This is a custom python package included in Constellation. It's also important that you create a client instance **after** you start the REST server, because the server creates a secret that the client needs to know to communicate with the server.\n",
     "\n",
-    "After the import succeeds, we then create a Python object that communicates with CONSTELLATION on our behalf. CONSTELLATION provides communication with the outside world using HTTP (as if it were a web server) and JSON (a common data format). The ``constellation_client`` library hides these details so you can just use Python."
+    "After the import succeeds, we then create a Python object that communicates with CONSTELLATION on our behalf. CONSTELLATION provides communication with the outside world using HTTP (as if it were a web server) and JSON (a common data format). The ``constellation_client`` library hides these details so you can just use Python.\n",
+    "\n",
+    "# IMPORTANT\n",
+    "If the \"REST Directory\" has been changed in Constellation's options, you must run the following to point constellation_client to the new folder for the \"REST Directory\". Be sure to replace `C:\\Path\\To\\Directory\\` with the actual filepath of the directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cc.update_rest(r\"C:\\Path\\To\\Directory\\\")"
    ]
   },
   {


### PR DESCRIPTION
Update documentation for jupyter notebook to coincide with changes that allow a user to change the location that `rest.json` is created. Includes information about how to change directory that constellation_client will look in to find `rest.json`.

Related:
PR: https://github.com/constellation-app/constellation/pull/2096 
Issue: https://github.com/constellation-app/constellation/issues/2073