### PR TITLE
updated notebook to reflect recent changes made to blaze plugins

### DIFF
--- a/Analyst Training/Exercise 10 - Network Analysis With Python/notebooks_and_constellation.ipynb
+++ b/Analyst Training/Exercise 10 - Network Analysis With Python/notebooks_and_constellation.ipynb
@@ -985,7 +985,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also call plugins with parameters (if you know what they are). For example, the ``AddBlaze`` plugin accepts a node id to add a blaze to.\n",
+    "You can also call plugins with parameters (if you know what they are). For example, the ``AddCustomBlaze`` plugin accepts a node id to add a blaze to.\n",
     "\n",
     "Let's add a blaze to each ``example3.com`` node."
    ]
@@ -1008,7 +1008,7 @@
     "\n",
     "# Add a blaze to those nodes.\n",
     "#\n",
-    "cc.run_plugin('AddBlaze', args={'BlazeUtilities.vertex_ids': list(e3['source.[id]'])})"
+    "cc.run_plugin('AddCustomBlaze', args={'BlazeUtilities.vertex_ids': list(e3['source.[id]'])})"
    ]
   },
   {


### PR DESCRIPTION
Changes made here https://github.com/constellation-app/constellation/pull/2212 resulted in `AddBlaze` no longer being a plugin you could select. This in turn broke the notebook in Chapter 10 of the Analyst training.

The plugin was removed in favour of having default values added to `AddCustomBlaze` so this PR simply alters the calls in the notebook to call this plugin instead. Because the default values added to the plugin, no other changes should be necessary to make it work.