### PR TITLE
Fix the graph attributes used to customize the node labels in training

### DIFF
--- a/Analyst Training/Exercise 10 - Network Analysis With Python/notebooks_and_constellation.ipynb
+++ b/Analyst Training/Exercise 10 - Network Analysis With Python/notebooks_and_constellation.ipynb
@@ -904,7 +904,7 @@
    "outputs": [],
    "source": [
     "labels = 'Geo.Country;Orange;0.5'\n",
-    "df = pd.DataFrame({'node_labels_top': [labels], 'decorators': [';\"Geo.Country\";;;']})\n",
+    "df = pd.DataFrame({'node_top_labels': [labels], 'decorators': [';\"Geo.Country\";;;']})\n",
     "cc.set_graph_attributes(df)"
    ]
   },
@@ -924,7 +924,7 @@
    "outputs": [],
    "source": [
     "labels = 'Type;Teal;0.5|Label;LightBlue;1'\n",
-    "df = pd.DataFrame({'node_labels_bottom': [labels]})\n",
+    "df = pd.DataFrame({'node_bottom_labels': [labels]})\n",
     "cc.set_graph_attributes(df)"
    ]
   },


### PR DESCRIPTION
Fixed the incorrect graph attribute names used to customize the node labels displayed, in notebooks training document.

https://github.com/constellation-app/constellation/issues/2332