### PR TITLE
Fix typo in code example in notebook tutorial

### DIFF
--- a/Analyst Training/Exercise 10 - Network Analysis With Python/notebooks_and_constellation.ipynb
+++ b/Analyst Training/Exercise 10 - Network Analysis With Python/notebooks_and_constellation.ipynb
@@ -57,7 +57,9 @@
     "After the import succeeds, we then create a Python object that communicates with CONSTELLATION on our behalf. CONSTELLATION provides communication with the outside world using HTTP (as if it were a web server) and JSON (a common data format). The ``constellation_client`` library hides these details so you can just use Python.\n",
     "\n",
     "# IMPORTANT\n",
-    "If the \"REST Directory\" has been changed in Constellation's options, you must run the following to point constellation_client to the new folder for the \"REST Directory\". Be sure to replace `C:\\Path\\To\\Directory\\` with the actual filepath of the directory or the actual file itself."
+    "If the \"REST Directory\" has been changed in Constellation's options, you must run the following to point constellation_client to the new folder for the \"REST Directory\". Be sure to replace `C:\\Path\\To\\Directory\\` with the actual filepath of the directory or the actual file itself.\n",
+    "\n",
+    "NOTE: in the code example an extra backslash is added to the end, this is intentional for formatting the raw string."
    ]
   },
   {
@@ -66,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cc.update_rest(r\"C:\\Path\\To\\Directory\\\")"
+    "cc.update_rest(r\"C:\\Path\\To\\Directory\\\\\")"
    ]
   },
   {


### PR DESCRIPTION
Fixed typo in code example for setting the rest directory. Code throw error because of the raw string being incorrectly formatted.

Added extra info in the accompanying text explaining this too